### PR TITLE
fix(prisma): remove duplicated model definitions

### DIFF
--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -67,29 +67,6 @@ model Display {
   updatedAt          DateTime            @updatedAt
   users              UserDisplayAccess[]
   heartbeats         PlayerHeartbeat[]
-  id           Int       @id @default(autoincrement())
-  email        String    @unique
-  passwordHash String
-  role         Role
-  createdAt    DateTime  @default(now())
-  displays     UserDisplayAccess[]
-  media        MediaAsset[] @relation("MediaCreatedBy")
-  textSlides   TextSlide[]   @relation("SlideCreatedBy")
-  playlists    Playlist[]    @relation("PlaylistCreatedBy")
-}
-
-model Display {
-  id                Int       @id @default(autoincrement())
-  name              String
-  slug              String    @unique
-  timezone          String
-  isActive          Boolean   @default(true)
-  assignedPlaylistId Int?
-  assignedPlaylist  Playlist? @relation(fields: [assignedPlaylistId], references: [id])
-  createdAt         DateTime  @default(now())
-  updatedAt         DateTime  @updatedAt
-  users             UserDisplayAccess[]
-  heartbeats        PlayerHeartbeat[]
 }
 
 model UserDisplayAccess {
@@ -127,30 +104,6 @@ model TextSlide {
   createdById   Int
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
-  id            Int       @id @default(autoincrement())
-  kind          MediaKind
-  title         String
-  pathOrUrl     String
-  folderPath    String
-  tags          String?
-  durationHintSec Int?
-  width         Int?
-  height        Int?
-  createdBy     User      @relation("MediaCreatedBy", fields: [createdById], references: [id])
-  createdById   Int
-  createdAt     DateTime  @default(now())
-  playlistItems PlaylistItem[]
-}
-
-model TextSlide {
-  id          Int       @id @default(autoincrement())
-  title       String?
-  contentJSON String
-  thumbnailPath String
-  createdBy   User      @relation("SlideCreatedBy", fields: [createdById], references: [id])
-  createdById Int
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
   playlistItems PlaylistItem[]
 }
 
@@ -178,29 +131,6 @@ model PlaylistItem {
   refType       RefType
   refId         Int
   durationMs    Int
-  id          Int       @id @default(autoincrement())
-  name        String
-  description String?
-  overlayLogoAssetId Int?
-  showClock   Boolean  @default(false)
-  randomize   Boolean  @default(false)
-  createdBy   User     @relation("PlaylistCreatedBy", fields: [createdById], references: [id])
-  createdById Int
-  updatedAtBy Int?
-  updatedAt   DateTime @updatedAt
-  createdAt   DateTime @default(now())
-  items       PlaylistItem[]
-  displays    Display[]
-}
-
-model PlaylistItem {
-  id          Int       @id @default(autoincrement())
-  playlist    Playlist  @relation(fields: [playlistId], references: [id])
-  playlistId  Int
-  position    Int
-  refType     RefType
-  refId       Int
-  durationMs  Int
   startDateTime DateTime?
   endDateTime   DateTime?
   daypartStart  String?
@@ -219,14 +149,6 @@ model PlaylistItem {
 
 model AuditLog {
   id          Int         @id @default(autoincrement())
-  transition    Transition @default(FADE)
-  transitionMs  Int       @default(500)
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
-}
-
-model AuditLog {
-  id          Int      @id @default(autoincrement())
   actorUserId Int
   entityType  String
   entityId    Int
@@ -250,23 +172,3 @@ model Settings {
   defaultTimezone String
   cachePolicy     String?
 }
-  createdAt   DateTime @default(now())
-}
-
-model PlayerHeartbeat {
-  id          Int      @id @default(autoincrement())
-  display     Display  @relation(fields: [displayId], references: [id])
-  displayId   Int
-  at          DateTime @default(now())
-  playerVersion String
-  pageVisibilityState String
-  approxLatencyMs Int?
-}
-
-model Settings {
-  id            Int      @id @default(1)
-  defaultTimezone String
-  cachePolicy    String?
-}
-
-@@index([playlistId, position], name: "PlaylistItem_order")


### PR DESCRIPTION
## Summary
- remove duplicate Prisma model blocks so each model is defined once

## Testing
- `npm install --workspace packages/prisma --no-package-lock`
- `npx prisma format --schema packages/prisma/schema.prisma`
- `npx prisma generate --schema packages/prisma/schema.prisma`


------
https://chatgpt.com/codex/tasks/task_b_68af12d781ec8320819a6b25bf27f726